### PR TITLE
Add Support for PHP 8.

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4']
+        php-versions: ['7.3', '7.4', '8.0', '8.1']
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -7,21 +7,21 @@
         "filter"
     ],
     "license": "MIT",
-    "configure": {
+    "config": {
         "sort-packages": true
     },
     "require": {
-        "php": "^7.0",
-        "traderinteractive/exceptions": "^1.0"
+        "php": "^7.3 || ^8.0",
+        "traderinteractive/exceptions": "^2.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.0",
+        "squizlabs/php_codesniffer": "^3.2"
     },
     "autoload": {
         "psr-4": {
             "TraderInteractive\\Filter\\": "src"
         }
-    },
-    "require-dev": {
-        "phpunit/phpunit": "^6.5",
-        "php-coveralls/php-coveralls": "^2.1"
     },
     "scripts": {
         "lint": "vendor/bin/phpcs",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,15 +1,17 @@
-<phpunit colors="true" forceCoversAnnotation="true">
-    <testsuites>
-        <testsuite name="TraderInteractive Library Test Suite">
-            <directory suffix="Test.php">tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory>src</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="coverage-clover" target="./clover.xml"/>
-    </logging>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" forceCoversAnnotation="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory>src</directory>
+    </include>
+    <report>
+      <clover outputFile="./clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="TraderInteractive Library Test Suite">
+      <directory suffix="Test.php">tests</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/tests/ArraysTest.php
+++ b/tests/ArraysTest.php
@@ -25,44 +25,44 @@ final class ArraysTest extends TestCase
     /**
      * @test
      * @covers ::filter
-     * @expectedException \TraderInteractive\Exceptions\FilterException
-     * @expectedExceptionMessage Value '1' is not an array
      */
     public function filterFailNotArray()
     {
+        $this->expectException(\TraderInteractive\Exceptions\FilterException::class);
+        $this->expectExceptionMessage("Value '1' is not an array");
         Arrays::filter(1);
     }
 
     /**
      * @test
      * @covers ::filter
-     * @expectedException \TraderInteractive\Exceptions\FilterException
-     * @expectedExceptionMessage $value count of 0 is less than 1
      */
     public function filterFailEmpty()
     {
+        $this->expectException(\TraderInteractive\Exceptions\FilterException::class);
+        $this->expectExceptionMessage('$value count of 0 is less than 1');
         Arrays::filter([]);
     }
 
     /**
      * @test
      * @covers ::filter
-     * @expectedException \TraderInteractive\Exceptions\FilterException
-     * @expectedExceptionMessage $value count of 1 is less than 2
      */
     public function filterCountLessThanMin()
     {
+        $this->expectException(\TraderInteractive\Exceptions\FilterException::class);
+        $this->expectExceptionMessage('$value count of 1 is less than 2');
         Arrays::filter([0], 2);
     }
 
     /**
      * @test
      * @covers ::filter
-     * @expectedException \TraderInteractive\Exceptions\FilterException
-     * @expectedExceptionMessage $value count of 2 is greater than 1
      */
     public function filterCountGreaterThanMax()
     {
+        $this->expectException(\TraderInteractive\Exceptions\FilterException::class);
+        $this->expectExceptionMessage('$value count of 2 is greater than 1');
         Arrays::filter([0, 1], 1, 1);
     }
 


### PR DESCRIPTION
#### What does this PR do?
Add Support for PHP 8.
Backwards breaking; Remove support for PHP 7.2 and earlier
Upgrade to PHPUnit 9

#### Checklist
- [  ] Pull request contains a clear definition of changes
- [  ] Tests (either unit, integration, or acceptance) written and passing
- [  ] Relevant documentation produced and/or updated

