### PR TITLE
Add Arrays::implode

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -8,10 +8,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0', '8.1']
+        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ $value = \TraderInteractive\Filter\Arrays::flatten([[1, 2], [3, [4, 5]]]);
 assert($value === [1, 2, 3, 4, 5]);
 ```
 
+#### Arrays::implode
+
+This filter is a wrapper to the PHP `implode` function. It joins an array of strings with the optional glue string. 
+```php
+$value = \TraderInteractive\Filter\Arrays::implode(['lastname', 'email', 'phone'], ',');
+assert($value === 'lastname,email,phone');
+```
+
 #### Arrays::pad
 
 This filter pads an array to the specified length with a value. Padding optionally to the front or end of the array.

--- a/src/Arrays.php
+++ b/src/Arrays.php
@@ -212,6 +212,19 @@ final class Arrays
     }
 
     /**
+     * Joins array elements with a string.
+     *
+     * @param array  $input The array to be filtered.
+     * @param string $glue  The string to which each array element should be joined.
+     *
+     * @return string
+     */
+    public static function implode(array $input, string $glue = '') : string
+    {
+        return implode($glue, $input);
+    }
+
+    /**
      * Removes duplicate values from an array.
      *
      * @param array $input     The array to be filtered.

--- a/tests/ArraysTest.php
+++ b/tests/ArraysTest.php
@@ -267,4 +267,25 @@ final class ArraysTest extends TestCase
         $this->expectExceptionMessage($expectedException->getMessage());
         Arrays::unique($input, Arrays::ARRAY_UNIQUE_SORT_STRING, true);
     }
+
+    /**
+     * @test
+     * @covers ::implode
+     */
+    public function implodeWithGlue()
+    {
+        $glue = '_';
+        $input = [0, 1, 2];
+        $this->assertSame('0_1_2', Arrays::implode($input, $glue));
+    }
+
+    /**
+     * @test
+     * @covers ::implode
+     */
+    public function implodeWithDefaultGlue()
+    {
+        $input = ['a', 'b', 'c'];
+        $this->assertSame('abc', Arrays::implode($input));
+    }
 }


### PR DESCRIPTION
#### What does this PR do?
This pull request adds the `Arrays::implode` filter.  It is needed because the built-in `implode` function requires the $separator string to be the first argument of the call.  However the Filterer always pushes the value to be filtered as the first argument to any called filter.
#### Checklist
- [  ] Pull request contains a clear definition of changes
- [  ] Tests (either unit, integration, or acceptance) written and passing
- [  ] Relevant documentation produced and/or updated

